### PR TITLE
fix: implement embed() method in TransformersEngineWrapper

### DIFF
--- a/src/engines/transformer-engine-wrapper.ts
+++ b/src/engines/transformer-engine-wrapper.ts
@@ -185,9 +185,14 @@ export class TransformersEngineWrapper {
 
   async embed(input: string, options: any = {}) {
     if (!this.transformersPipeline || this.modelType !== 'feature-extraction') {
-      console.debug(`Feature extraction pipeline not initialized. ${input}, ${options}`);
-      throw new Error('Feature extraction pipeline not initialized.');
+      throw new Error('Feature extraction pipeline not initialized. Load a feature-extraction model first.');
     }
+    const result = await (this.transformersPipeline as any)(input, {
+      pooling: options.pooling ?? 'mean',
+      normalize: options.normalize ?? true,
+      ...options,
+    });
+    return result;
   }
 
   async generateImage(input: { text: string }, options: any = {}) {


### PR DESCRIPTION
## Summary
- The `embed()` method in `TransformersEngineWrapper` was checking for pipeline initialization but never actually computing embeddings, always returning `undefined`.
- Now delegates to the feature-extraction pipeline with proper `pooling` and `normalize` options, matching the existing `extractFeatures()` implementation.

Fixes #221

## Test plan
- [x] Build passes (`npm run build`)
- [x] Existing tests pass (`npm test`)
- [ ] Manual verification: load a feature-extraction model and call `embed()` to confirm it returns embeddings