### PR TITLE
fix: resolve infinite recursion in areElementsSemanticallyRelated()

### DIFF
--- a/src/core/agent/content-identifier.ts
+++ b/src/core/agent/content-identifier.ts
@@ -546,8 +546,8 @@ export class ContentSectionAnalyzer {
 
         if (matchesPatterns) return true;
 
-        // Fallback to existing semantic relationship checks
-        return this.areElementsSemanticallyRelated(el1, el2);
+        // No semantic relationship found
+        return false;
     }
 
     private isElementInSections(element: Element, sections: ContentSection[]): boolean {


### PR DESCRIPTION
## Summary
- Fixed infinite recursion bug in `ContentSectionAnalyzer.areElementsSemanticallyRelated()` that caused guaranteed stack overflow
- The method was calling itself with the same arguments as a fallback when class patterns didn't match
- Replaced the recursive call with `return false` as the correct base case

## Test plan
- [x] Build passes
- [x] Existing tests pass
- [ ] Please test manually with DOM operations that trigger content section analysis

Fixes #218