### PR TITLE
fix: remove async Promise constructor anti-pattern

### DIFF
--- a/src/core/llm/index.ts
+++ b/src/core/llm/index.ts
@@ -213,29 +213,18 @@ export class BrowserAI {
   }
 
   async clearModelCache(): Promise<void> {
-    return new Promise<void>(async (resolve, reject) => {
-      try {
-        // MLC models are stored in Cache Storage with specific prefixes
-        const cacheNames = ['webllm/config', 'webllm/wasm', 'webllm/model'];
-        
-        // Get all cache names
-        const existingCacheNames = await caches.keys();
-        
-        // Filter caches that match our MLC prefixes
-        const mlcCaches = existingCacheNames.filter(name => 
-          cacheNames.some(prefix => name.includes(prefix))
-        );
-        
-        // Delete all matching caches
-        await Promise.all(mlcCaches.map(name => caches.delete(name)));
-        
-        console.log('Successfully cleared MLC model cache');
-        resolve();
-      } catch (error) {
-        console.error('Error clearing model cache:', error);
-        reject(error);
-      }
-    });
+    try {
+      const cacheNames = ['webllm/config', 'webllm/wasm', 'webllm/model'];
+      const existingCacheNames = await caches.keys();
+      const mlcCaches = existingCacheNames.filter(name =>
+        cacheNames.some(prefix => name.includes(prefix))
+      );
+      await Promise.all(mlcCaches.map(name => caches.delete(name)));
+      console.log('Successfully cleared MLC model cache');
+    } catch (error) {
+      console.error('Error clearing model cache:', error);
+      throw error;
+    }
   }
 
   async clearSpecificModelCache(modelIdentifier: string): Promise<void> {

--- a/src/engines/mlc-engine-wrapper.ts
+++ b/src/engines/mlc-engine-wrapper.ts
@@ -784,29 +784,18 @@ export class MLCEngineWrapper {
   }
 
   async clearModelCache(): Promise<void> {
-    return new Promise<void>(async (resolve, reject) => {
-      try {
-        // MLC models are stored in Cache Storage with specific prefixes
-        const cacheNames = ['webllm/config', 'webllm/wasm', 'webllm/model'];
-        
-        // Get all cache names
-        const existingCacheNames = await caches.keys();
-        
-        // Filter caches that match our MLC prefixes
-        const mlcCaches = existingCacheNames.filter(name => 
-          cacheNames.some(prefix => name.includes(prefix))
-        );
-        
-        // Delete all matching caches
-        await Promise.all(mlcCaches.map(name => caches.delete(name)));
-        
-        console.log('Successfully cleared MLC model cache');
-        resolve();
-      } catch (error) {
-        console.error('Error clearing model cache:', error);
-        reject(error);
-      }
-    });
+    try {
+      const cacheNames = ['webllm/config', 'webllm/wasm', 'webllm/model'];
+      const existingCacheNames = await caches.keys();
+      const mlcCaches = existingCacheNames.filter(name =>
+        cacheNames.some(prefix => name.includes(prefix))
+      );
+      await Promise.all(mlcCaches.map(name => caches.delete(name)));
+      console.log('Successfully cleared MLC model cache');
+    } catch (error) {
+      console.error('Error clearing model cache:', error);
+      throw error;
+    }
   }
   
   async clearSpecificModel(modelIdentifier: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Refactored `clearModelCache()` in both `MLCEngineWrapper` and `BrowserAI` class
- Replaced `new Promise(async (resolve, reject) => {...})` with direct async/await
- Errors are now properly propagated via `throw` instead of potentially being swallowed

## Test plan
- [x] Build passes
- [x] Existing tests pass
- [ ] Test `clearModelCache()` in browser with models cached

Fixes #219