### PR TITLE
fix: use consistent max_tokens parameter name in realtime-chat-demo

### DIFF
--- a/examples/realtime-chat-demo/src/App.tsx
+++ b/examples/realtime-chat-demo/src/App.tsx
@@ -80,7 +80,7 @@ function App() {
       // Generate AI response
       const response = await chatAI.generateText("You are an helpful AI friend which lives inside browser and is always happy to help.Answer should be in following language: " + language + ". Reply to this message: \n" + transcribedText, {
         temperature: 0.7,
-        maxTokens: 100,
+        max_tokens: 100,
       });
 
       const voices = {


### PR DESCRIPTION
## Summary
- Changed `maxTokens: 100` to `max_tokens: 100` in realtime-chat-demo
- Matches the documented API (`docs/pages/api_reference/generate_text.mdx`) and other examples

## Test plan
- [x] Verified parameter name matches API reference
- [ ] Test realtime-chat-demo to confirm token limit is respected

Fixes #225