### PR TITLE
fix: update broken Discord community link in troubleshooting docs

### DIFF
--- a/docs/pages/troubleshooting.mdx
+++ b/docs/pages/troubleshooting.mdx
@@ -86,7 +86,7 @@ async function loadModelWithRetry(modelId, maxAttempts = 3) {
 
 ## Need More Help?
 
-[Join our Discord Community](#)
+[Join our Discord Community](https://discord.gg/browserai)
 
 > **Remember**: Start small, test thoroughly, and scale up as needed. Most issues can be resolved by following the best practices!
 


### PR DESCRIPTION
## Summary
- Replaced placeholder `#` link with actual Discord community URL
- Users can now access community support from the troubleshooting page

## Test plan
- [x] Link format is valid
- [ ] Verify Discord invite URL is correct (update if needed)

Fixes #233