### PR TITLE
fix: remove typo in supported models documentation

### DIFF
--- a/docs/pages/supported_models.mdx
+++ b/docs/pages/supported_models.mdx
@@ -46,7 +46,7 @@ BrowserAI comes with a carefully curated selection of models optimized for brows
 
 | Model | Description | Best For | Memory Required |
 |-------|-------------|----------|-----------------|
-| **janus-1.3 (Coming Soon)b** | 1.3B parameters | Vision-language tasks | 1GB |
+| **janus-1.3 (Coming Soon)** | 1.3B parameters | Vision-language tasks | 1GB |
 
 ## Coming Soon
 


### PR DESCRIPTION
## Summary
- Removed extra 'b' character: `janus-1.3 (Coming Soon)b` -> `janus-1.3 (Coming Soon)`

Fixes #234