### PR TITLE
fix: remove async Promise constructor anti-pattern

### DIFF
--- a/src/core/llm/index.ts
+++ b/src/core/llm/index.ts
@@ -213,29 +213,18 @@ export class BrowserAI {
   }
 
   async clearModelCache(): Promise<void> {
-    return new Promise<void>(async (resolve, reject) => {
-      try {
-        // MLC models are stored in Cache Storage with specific prefixes
-        const cacheNames = ['webllm/config', 'webllm/wasm', 'webllm/model'];
-        
-        // Get all cache names
-        const existingCacheNames = await caches.keys();
-        
-        // Filter caches that match our MLC prefixes
-        const mlcCaches = existingCacheNames.filter(name => 
-          cacheNames.some(prefix => name.includes(prefix))
-        );
-        
-        // Delete all matching caches
-        await Promise.all(mlcCaches.map(name => caches.delete(name)));
-        
-        console.log('Successfully cleared MLC model cache');
-        resolve();
-      } catch (error) {
-        console.error('Error clearing model cache:', error);
-        reject(error);
-      }
-    });
+    try {
+      const cacheNames = ['webllm/config', 'webllm/wasm', 'webllm/model'];
+      const existingCacheNames = await caches.keys();
+      const mlcCaches = existingCacheNames.filter(name =>
+        cacheNames.some(prefix => name.includes(prefix))
+      );
+      await Promise.all(mlcCaches.map(name => caches.delete(name)));
+      console.log('Successfully cleared MLC model cache');
+    } catch (error) {
+      console.error('Error clearing model cache:', error);
+      throw error;
+    }
   }
 
   async clearSpecificModelCache(modelIdentifier: string): Promise<void> {

--- a/src/engines/mlc-engine-wrapper.ts
+++ b/src/engines/mlc-engine-wrapper.ts
@@ -784,29 +784,18 @@ export class MLCEngineWrapper {
   }
 
   async clearModelCache(): Promise<void> {
-    return new Promise<void>(async (resolve, reject) => {
-      try {
-        // MLC models are stored in Cache Storage with specific prefixes
-        const cacheNames = ['webllm/config', 'webllm/wasm', 'webllm/model'];
-        
-        // Get all cache names
-        const existingCacheNames = await caches.keys();
-        
-        // Filter caches that match our MLC prefixes
-        const mlcCaches = existingCacheNames.filter(name => 
-          cacheNames.some(prefix => name.includes(prefix))
-        );
-        
-        // Delete all matching caches
-        await Promise.all(mlcCaches.map(name => caches.delete(name)));
-        
-        console.log('Successfully cleared MLC model cache');
-        resolve();
-      } catch (error) {
-        console.error('Error clearing model cache:', error);
-        reject(error);
-      }
-    });
+    try {
+      const cacheNames = ['webllm/config', 'webllm/wasm', 'webllm/model'];
+      const existingCacheNames = await caches.keys();
+      const mlcCaches = existingCacheNames.filter(name =>
+        cacheNames.some(prefix => name.includes(prefix))
+      );
+      await Promise.all(mlcCaches.map(name => caches.delete(name)));
+      console.log('Successfully cleared MLC model cache');
+    } catch (error) {
+      console.error('Error clearing model cache:', error);
+      throw error;
+    }
   }
   
   async clearSpecificModel(modelIdentifier: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Refactored `clearModelCache()` in both `MLCEngineWrapper` (`src/engines/mlc-engine-wrapper.ts`) and `BrowserAI` (`src/core/llm/index.ts`) to use direct `async/await` instead of wrapping async functions inside `new Promise()` constructors.
- The previous pattern (`new Promise<void>(async (resolve, reject) => {...})`) is a well-known anti-pattern that can silently swallow errors if an exception is thrown before `reject()` is called, or if `resolve()`/`reject()` are accidentally not called on all code paths.
- Now errors are properly propagated via `throw` rather than `reject()`, and the methods rely on the native async function return for the resolved promise.

## Test plan
- [x] `npm run build` passes successfully
- [x] `npm test` passes (2/2 tests)
- [x] Verified no `return new Promise<void>(async` pattern remains in either file
- [ ] Manual verification: call `clearModelCache()` and confirm cache clearing still works
- [ ] Manual verification: simulate a cache deletion error and confirm the error propagates correctly to the caller

Fixes #219