### PR TITLE
Fix race condition in generateResponse model auto-loading

### DIFF
--- a/src/core/llm/index.ts
+++ b/src/core/llm/index.ts
@@ -20,6 +20,7 @@ export class BrowserAI {
   private audioChunks: Blob[] = [];
   private modelIdentifier: string | null = null;
   private customModels: Record<string, ModelConfig> = {};
+  private modelLoadingPromise: Promise<void> | null = null;
 
   constructor() {
     this.engine = null;
@@ -167,8 +168,17 @@ export class BrowserAI {
     if (!this.modelIdentifier) {
       throw new Error('No model loaded. Please call loadModel first.');
     }
-    if (this.currentModel?.modelName !== this.modelIdentifier) {
-      await this.loadModel(this.modelIdentifier);
+    if (!this.currentModel || this.currentModel.modelName !== this.modelIdentifier) {
+      if (this.modelLoadingPromise) {
+        await this.modelLoadingPromise;
+      } else {
+        this.modelLoadingPromise = this.loadModel(this.modelIdentifier);
+        try {
+          await this.modelLoadingPromise;
+        } finally {
+          this.modelLoadingPromise = null;
+        }
+      }
     }
     const response = await this.generateText(text);
     return response as string;


### PR DESCRIPTION
## Summary
- Replaced fragile optional chaining (`this.currentModel?.modelName`) with explicit null check
- Added `modelLoadingPromise` field to prevent concurrent `generateResponse()` calls from triggering multiple simultaneous `loadModel()` calls
- Concurrent callers now await the same loading promise instead of each starting their own

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes
- [ ] Manual test: call `generateResponse()` concurrently and verify model loads only once

Fixes #223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where concurrent model loading requests could cause duplicate loads and instability. Model loading operations are now properly serialized for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->