### PR TITLE
Remove dead generateSpeech with broken /api/speech endpoint

### DIFF
--- a/examples/realtime-chat-demo/src/App.tsx
+++ b/examples/realtime-chat-demo/src/App.tsx
@@ -123,28 +123,6 @@ function App() {
     }
   };
 
-  const generateSpeech = async (text: string): Promise<ArrayBuffer> => {
-    try {
-      // Your speech generation logic here
-      const response = await fetch('/api/speech', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ text }),
-      });
-
-      if (!response.ok) {
-        throw new Error('Speech generation failed');
-      }
-
-      return await response.arrayBuffer();
-    } catch (error) {
-      console.error('Error generating speech:', error);
-      throw error;
-    }
-  };
-
   useEffect(() => {
     const handleKeyDown = async (e: KeyboardEvent) => {
       if (e.code === 'Space' && !e.repeat && !isListening && !isLoading && messages.length > 0) {


### PR DESCRIPTION
## Summary
- Removed unused `generateSpeech` function that called a non-existent `/api/speech` server endpoint
- The TTS functionality already works correctly via `ttsAI.textToSpeech()` in `handleStopListening`
- This dead code would always 404 since BrowserAI is client-side only

## Test plan
- [x] Verified `generateSpeech` is never referenced elsewhere in the file
- [x] TTS still works through the existing `ttsAI.textToSpeech()` call
- [ ] Manual test: run the realtime-chat-demo and verify TTS works

Fixes #224