### PR TITLE
Move hardcoded PostHog API key to environment variable

### DIFF
--- a/examples/audio-demo/.env.example
+++ b/examples/audio-demo/.env.example
@@ -1,0 +1,3 @@
+# PostHog analytics (optional)
+VITE_POSTHOG_KEY=
+VITE_POSTHOG_HOST=https://us.i.posthog.com

--- a/examples/audio-demo/src/components/ChatInterface.tsx
+++ b/examples/audio-demo/src/components/ChatInterface.tsx
@@ -450,8 +450,10 @@ const initPostHog = () => {
     if (typeof posthog !== 'undefined') {
       // Wait for next tick to ensure document is ready
       setTimeout(() => {
-        posthog.init('phc_zZuhhgvhx49iRC6ftmFcnVKZrlraLCyPeFbs5mWzmxp', {
-          api_host: 'https://us.i.posthog.com',
+        const posthogKey = import.meta.env.VITE_POSTHOG_KEY;
+        if (!posthogKey) return;
+        posthog.init(posthogKey, {
+          api_host: import.meta.env.VITE_POSTHOG_HOST || 'https://us.i.posthog.com',
           person_profiles: 'identified_only',
           loaded: (posthog) => {
             posthog.debug(false);


### PR DESCRIPTION
## Summary
- Replaced hardcoded PostHog API key with `VITE_POSTHOG_KEY` environment variable
- Analytics only initializes when the env var is present
- Added `.env.example` template for the audio-demo example

## Test plan
- [x] Without env var: analytics silently skipped
- [x] With env var: analytics initializes as before
- [ ] Manual test in audio-demo

Fixes #232