### PR TITLE
Use stable onnxruntime-web version instead of dev build

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@mlc-ai/web-llm": "^0.2.79",
     "@types/pdfjs-dist": "^2.10.378",
     "mammoth": "^1.9.0",
-    "onnxruntime-web": "1.21.0-dev.20250206-d981b153d3",
+    "onnxruntime-web": "^1.21.0",
     "pdfjs-dist": "^4.10.38",
     "phonemizer": "^1.2.1",
     "tesseract.js": "^6.0.0"


### PR DESCRIPTION
## Summary
- Replaced pre-release `onnxruntime-web@1.21.0-dev.20250206-d981b153d3` with stable `^1.21.0`
- Dev builds may be unstable and are not recommended for production

## Test plan
- [x] `npm install` succeeds
- [x] `npm run build` passes
- [x] `npm test` passes
- [ ] Manual test: verify ONNX models still load correctly

Fixes #235