### PR TITLE
Remove duplicate CORS header in audio-demo

### DIFF
--- a/examples/audio-demo/public/_headers
+++ b/examples/audio-demo/public/_headers
@@ -2,4 +2,3 @@
   Access-Control-Allow-Origin: *
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp
-  Access-Control-Allow-Origin: *


### PR DESCRIPTION
## Summary
- Removed duplicate `Access-Control-Allow-Origin: *` header entry
- CORS wildcard is kept as it is needed for loading models from external CDNs (HuggingFace)
- COOP/COEP headers remain for SharedArrayBuffer support

## Test plan
- [x] Verified no duplicate entries remain

Fixes #244

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed duplicate header configuration from the example project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->