### PR TITLE
Make worker initialization timeout configurable

### DIFF
--- a/src/engines/mlc-engine-wrapper.ts
+++ b/src/engines/mlc-engine-wrapper.ts
@@ -74,6 +74,7 @@ const workerCode = `
 
 interface MLCLoadModelOptions {
   useWorker?: boolean;
+  workerTimeout?: number;
   onProgress?: (progress: any) => void;
   quantization?: string;
   [key: string]: any;
@@ -505,7 +506,7 @@ export class MLCEngineWrapper {
 
           const timeout = setTimeout(() => {
             reject(new Error('Worker initialization timeout'));
-          }, 10000);
+          }, options.workerTimeout || 10000);
 
           this.worker.onmessage = (msg) => {
             if (msg.data.type === 'ready') {


### PR DESCRIPTION
## Summary
- Added `workerTimeout` option to `MLCLoadModelOptions` interface
- Defaults to 10000ms (unchanged behavior)
- Users can now pass `{ workerTimeout: 30000 }` for slower connections

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes

Fixes #249