### PR TITLE
Standardize React version across all examples

### DIFF
--- a/examples/WIP-browser-agent-demo/package.json
+++ b/examples/WIP-browser-agent-demo/package.json
@@ -12,13 +12,13 @@
   "dependencies": {
     "@browserai/browserai": "^2.0.4",
     "lucide-react": "^0.474.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
-    "@types/react": "^18.3.18",
-    "@types/react-dom": "^18.3.5",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.17.0",

--- a/examples/audio-demo/package.json
+++ b/examples/audio-demo/package.json
@@ -17,13 +17,13 @@
     "@huggingface/transformers": "^3.2.4",
     "@mlc-ai/web-llm": "^0.2.77",
     "posthog-js": "^1.205.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
-    "@types/react": "^18.3.18",
-    "@types/react-dom": "^18.3.5",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.17.0",
     "eslint-plugin-react-hooks": "^5.0.0",

--- a/examples/chat-demo/package.json
+++ b/examples/chat-demo/package.json
@@ -21,13 +21,13 @@
     "lucide-react": "^0.473.0",
     "markdown-it": "^14.1.0",
     "posthog-js": "^1.205.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
-    "@types/react": "^18.3.18",
-    "@types/react-dom": "^18.3.5",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.17.0",

--- a/examples/database-demos/indexeddb-demo/package.json
+++ b/examples/database-demos/indexeddb-demo/package.json
@@ -11,13 +11,13 @@
   },
   "dependencies": {
     "@browserai/browserai": "^2.0.4",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
-    "@types/react": "^18.3.18",
-    "@types/react-dom": "^18.3.5",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.17.0",
     "eslint-plugin-react-hooks": "^5.0.0",

--- a/examples/realtime-chat-demo/package.json
+++ b/examples/realtime-chat-demo/package.json
@@ -23,14 +23,14 @@
     "lucide-react": "^0.473.0",
     "markdown-it": "^14.1.0",
     "posthog-js": "^1.205.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "tailwind-merge": "^3.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
-    "@types/react": "^18.3.18",
-    "@types/react-dom": "^18.3.5",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.17.0",

--- a/examples/tts-demo/package.json
+++ b/examples/tts-demo/package.json
@@ -12,13 +12,13 @@
   "dependencies": {
     "@browserai/browserai": "^2.0.4",
     "@emotion/styled": "^11.14.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
-    "@types/react": "^18.3.18",
-    "@types/react-dom": "^18.3.5",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.17.0",
     "eslint-plugin-react-hooks": "^5.0.0",


### PR DESCRIPTION
## Summary
- Updated all example projects to use React `^19.0.0` and `@types/react: ^19.0.8`
- Previously 6 examples used React 18.3.1 and 2 used React 19.0.0

## Test plan
- [x] All package.json files updated consistently
- [ ] Verify examples still build with React 19

Fixes #250