### PR TITLE
Add proper resource disposal for all engine types

### DIFF
--- a/src/core/llm/index.ts
+++ b/src/core/llm/index.ts
@@ -267,10 +267,13 @@ export class BrowserAI {
       this.mediaRecorder.stop();
     }
     this.mediaRecorder = null;
-    if (this.engine instanceof MLCEngineWrapper) {
+    this.audioChunks = [];
+
+    if (this.engine) {
       this.engine.dispose();
     }
     this.engine = null;
     this.currentModel = null;
+    this.modelIdentifier = null;
   }
 }

--- a/src/engines/transformer-engine-wrapper.ts
+++ b/src/engines/transformer-engine-wrapper.ts
@@ -228,4 +228,12 @@ export class TransformersEngineWrapper {
       throw error;
     }
   }
+
+  dispose() {
+    this.transformersPipeline = null;
+    this.ttsEngine = null;
+    this.imageProcessor = null;
+    this.multimodalModel = null;
+    this.modelType = null;
+  }
 }


### PR DESCRIPTION
## Summary
- Added `dispose()` method to `TransformersEngineWrapper` to clean up pipelines, TTS engine, and multimodal models
- Updated `BrowserAI.dispose()` to properly clean up:
  - Active MediaRecorder (stops if recording)
  - Audio chunks buffer
  - Engine resources (both MLC and Transformers)
  - Model state references

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes
- [ ] Manual test: call dispose() after using various model types

Fixes #230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resource cleanup during AI engine disposal to ensure all components, audio data, and internal state are properly released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->