### PR TITLE
Add input validation for image and DOCX file parsers

### DIFF
--- a/src/core/parsers/docx.ts
+++ b/src/core/parsers/docx.ts
@@ -86,6 +86,13 @@ export class DOCXParser {
    * @returns Promise resolving to parsed DOCX data
    */
   static async parseFromFile(file: File, options: DOCXParseOptions = {}): Promise<DOCXParseResult> {
+    if (!file) {
+      throw new Error('File is required');
+    }
+    if (!this.isValidDocxFile(file) && !this.isValidDocFile(file)) {
+      throw new Error(`Invalid document file type: "${file.type}". Supported types: .doc, .docx`);
+    }
+
     const debugInfo: string[] = options.debug
       ? [`Parsing DOCX file: ${file.name} (${(file.size / 1024).toFixed(2)} KB)`]
       : [];

--- a/src/core/parsers/image.ts
+++ b/src/core/parsers/image.ts
@@ -68,6 +68,13 @@ export class ImageParser {
    * Parse text from an image file
    */
   static async parseFromFile(file: File, options: ImageParseOptions = {}): Promise<ImageParseResult> {
+    if (!file) {
+      throw new Error('File is required');
+    }
+    if (!this.isValidImageFile(file)) {
+      throw new Error(`Invalid image file type: "${file.type}". Supported types: image/jpeg, image/png`);
+    }
+
     const debugInfo: string[] = [];
     if (options.debug) debugInfo.push(`Starting image parsing: ${file.name}`);
 


### PR DESCRIPTION
## Summary
- Added file existence and MIME type validation to `ImageParser.parseFromFile()`
- Added file existence and type validation to `DOCXParser.parseFromFile()`
- Both provide clear error messages listing supported types
- PDF parser already had validation in `processPdfFile()`

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes
- [ ] Manual test: pass invalid file types and verify error messages

Fixes #240