### PR TITLE
Bump @sauravpanda/flare to 0.2.12

### DIFF
--- a/examples/benchmark/index.html
+++ b/examples/benchmark/index.html
@@ -629,7 +629,7 @@
         if (!flareWorker) {
           log('Starting Flare worker...', 'info');
           ensureFlareWorker();
-          const CDN = 'https://cdn.jsdelivr.net/npm/@sauravpanda/flare@0.2.11/pkg';
+          const CDN = 'https://cdn.jsdelivr.net/npm/@sauravpanda/flare@0.2.12/pkg';
           await flareCall('init', {
             jsUrl: `${CDN}/flare_web.js`,
             wasmUrl: `${CDN}/flare_web_bg.wasm`,


### PR DESCRIPTION
Re-enables WebGPU in worker contexts. See https://github.com/sauravpanda/flarellm/pull/498 for the upstream fix. After npm publish completes, the benchmark should drop back to CPU-only only if WebGPU is genuinely unavailable rather than always.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Flare engine CDN package version from 0.2.11 to 0.2.12 in the benchmark example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->