### PR TITLE
Bump @sauravpanda/flare to 0.2.13

### DIFF
--- a/examples/benchmark/index.html
+++ b/examples/benchmark/index.html
@@ -594,7 +594,7 @@
       async function loadFlareEngine(config) {
         if (!flareLib) {
           log('Loading @sauravpanda/flare WASM from CDN...', 'info');
-          const CDN = 'https://cdn.jsdelivr.net/npm/@sauravpanda/flare@0.2.12/pkg';
+          const CDN = 'https://cdn.jsdelivr.net/npm/@sauravpanda/flare@0.2.13/pkg';
           const wasmUrl = `${CDN}/flare_web_bg.wasm`;
 
           // Fetch the JS module source, patch the WASM URL, and load via blob


### PR DESCRIPTION
Cuts peak WASM memory during load from ~680 MB to ~410 MB by deferring f32 dequant for per-layer matmul weights. See https://github.com/sauravpanda/flarellm/pull/499.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Flare engine dependency to version 0.2.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->