### PR TITLE
Benchmark: async GPU decode via next_token_async (flare 0.2.15)

### DIFF
--- a/examples/benchmark/index.html
+++ b/examples/benchmark/index.html
@@ -597,7 +597,7 @@
         if (!flareLib) {
           log('Loading @sauravpanda/flare WASM from CDN...', 'info');
           T('fetching flare_web.js from CDN');
-          const CDN = 'https://cdn.jsdelivr.net/npm/@sauravpanda/flare@0.2.13/pkg';
+          const CDN = 'https://cdn.jsdelivr.net/npm/@sauravpanda/flare@0.2.15/pkg';
           const wasmUrl = `${CDN}/flare_web_bg.wasm`;
 
           const jsResp = await fetch(`${CDN}/flare_web.js`, { cache: 'no-cache' });
@@ -724,12 +724,12 @@
         T('FlareEngine.load returned');
         bytes = null; // drop source buffer before warmup / GPU upload
 
-        // GPU prefill is currently deadlocked on Chrome main-thread wasm due
-        // to wgpu's sync readback pattern (map_async callback can't fire
-        // while we're mid-sync-WASM-call).  Force CPU path until the async
-        // readback refactor lands upstream.
-        const USE_GPU = new URL(location.href).searchParams.get('gpu') === '1';
-        T(`init_gpu: ${USE_GPU ? 'ENABLED via ?gpu=1' : 'SKIPPED (CPU only)'}`);
+        // GPU decode now works via `next_token_async` (flare-web 0.2.14).
+        // Prefill still runs sync → uses the CPU backend's Q8_0 SIMD path;
+        // decode reads back through the async readback so the WebGPU
+        // `map_async` callback can fire.  `?gpu=0` opts out for debugging.
+        const USE_GPU = new URL(location.href).searchParams.get('gpu') !== '0';
+        T(`init_gpu: ${USE_GPU ? 'ENABLED (async decode)' : 'SKIPPED via ?gpu=0'}`);
         try {
           const gpuOk = USE_GPU ? await flareEngine.init_gpu() : false;
           T(`init_gpu complete, gpuOk=${gpuOk}`);
@@ -792,8 +792,12 @@
         let output = '';
 
         tInf('entering decode loop');
+        // Prefer the async variant when available (flare-web >= 0.2.14) so
+        // WebGPU's map_async callback can fire between tokens.  Sync
+        // next_token is only safe on CPU backend.
+        const hasAsync = typeof flareEngine.next_token_async === 'function';
         while (!flareEngine.stream_done) {
-          const id = flareEngine.next_token();
+          const id = hasAsync ? await flareEngine.next_token_async() : flareEngine.next_token();
           if (id === undefined) break;
           tokenCount++;
           output += flareEngine.decode_token_chunk(id);


### PR DESCRIPTION
Flips the Flare benchmark to GPU-backed decode using the new async API landed in flare-web 0.2.14/0.2.15.

## Result on SmolLM2-135M Q8_0 (M-series Mac, Chrome)

| | Flare | MLC | Transformers.js |
|---|---|---|---|
| Decode | **173 tok/s** | 101 tok/s | 16 tok/s |
| TTFT | 137 ms | 19 ms | 4349 ms |
| Load | **0.2 s** | 0.4 s | 2.0 s |

Flare now leads decode throughput by 71% over MLC. Load is 2× faster. TTFT still trails MLC because prefill runs on CPU — closing that gap is the next upstream refactor (async prefill propagation in flare-web).

## Changes
- Bump CDN pin 0.2.13 → 0.2.15 (adds `next_token_async` + wasm32 prefill CPU fallback)
- Decode loop: `await flareEngine.next_token_async()` when available, fall back to sync `next_token()` otherwise
- GPU is the default; `?gpu=0` opts into CPU-only for debugging

## Test plan
- [x] `npx jest` — 62 passing
- [x] Manual run: 173 tok/s confirmed in screenshot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU is now enabled by default in benchmarks; use `?gpu=0` to disable.
  * Updated benchmark to use the latest CDN version.

* **Improvements**
  * Enhanced token advancement with async processing when available for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->